### PR TITLE
Allow jitpack.io to build artifacts 

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,13 @@
+install:
+- VERSION=2.2-SNAPSHOT-20190402.1
+- ant 
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j-fop-ext-0.20.5-complete -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/barcode4j-fop-ext-0.20.5-complete.jar
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j-fop-ext-0.20.5 -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/barcode4j-fop-ext-0.20.5.jar
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j-fop-ext-complete -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/barcode4j-fop-ext-complete.jar
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j-fop-ext -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/barcode4j-fop-ext.jar
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j-light -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/barcode4j-light.jar
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j-xgc -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/barcode4j-xgc.jar
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/barcode4j.jar
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j-fop-ext-resources -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/resource-jars/barcode4j-fop-ext-resources.jar
+- mvn install:install-file -DgroupId=com.github.mpdude -DartifactId=barcode4j-xgc-resources -Dversion=$VERSION -Dpackaging=jar -DgeneratePom=true -Dfile=build/resource-jars/barcode4j-xgc-resources.jar
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+			    http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+	<groupId>com.github.mpdude</groupId>
+
+    <artifactId>barcode4j</artifactId>
+	<version>2.2-SNAPSHOT-20190402.1</version>
+
+</project>


### PR DESCRIPTION
This puts configuration files in place so that jitpack.io can build artifacts for the "trunk" branch (2.2-SNAPSHOT). That branch allows to generate QR codes: http://barcode4j.sourceforge.net/trunk/symbol-qr.html

See https://gist.github.com/jitpack-io/f928a858aa5da08ad9d9662f982da983 and
https://twitter.com/jitpack/status/1113114078807982113 for the initial pointers.

